### PR TITLE
Changed error message from always "Bad Request" to api.cloudflare err…

### DIFF
--- a/src/API/AbstractAPIClient.php
+++ b/src/API/AbstractAPIClient.php
@@ -65,6 +65,12 @@ abstract class AbstractAPIClient implements APIInterface
 
             return $response;
         } catch (RequestException $e) {
+            $jsonResponse = json_decode($e->getResponse()->getBody(), true);
+            $errorMessage = $e->getMessage();
+            if (count($jsonResponse['errors']) > 0) {
+                $errorMessage = $jsonResponse['errors'][0]['message'];
+            }
+
             $this->logAPICall($this->getAPIClientName(), array(
                 'type' => 'request',
                 'method' => $request->getMethod(),
@@ -72,9 +78,9 @@ abstract class AbstractAPIClient implements APIInterface
                 'headers' => $request->getHeaders(),
                 'params' => $request->getParameters(),
                 'body' => $request->getBody(), ), true);
-            $this->logAPICall($this->getAPIClientName(), array('type' => 'response', 'code' => $e->getCode(), 'body' => $e->getMessage(), 'stacktrace' => $e->getTraceAsString()), true);
+            $this->logAPICall($this->getAPIClientName(), array('type' => 'response', 'code' => $e->getCode(), 'body' => $errorMessage, 'stacktrace' => $e->getTraceAsString()), true);
 
-            return $this->createAPIError($e->getMessage());
+            return $this->createAPIError($errorMessage);
         }
     }
 

--- a/src/API/AbstractAPIClient.php
+++ b/src/API/AbstractAPIClient.php
@@ -84,7 +84,22 @@ abstract class AbstractAPIClient implements APIInterface
         }
     }
 
-    public function logAPICall($api, $message, $isError)
+    /**
+     * @param RequestException $object
+     *
+     * @return string
+     */
+    public function getErrorMessage(RequestException $error)
+    {
+        return $error->getMessage();
+    }
+
+    /**
+     * @param string $apiName
+     * @param array  $message
+     * @param bool   $isError
+     */
+    public function logAPICall(string $apiName, array $message, bool $isError)
     {
         $logLevel = 'error';
         if ($isError === false) {
@@ -95,7 +110,7 @@ abstract class AbstractAPIClient implements APIInterface
             $message = print_r($message, true);
         }
 
-        $this->logger->$logLevel('['.$api.'] '.$message);
+        $this->logger->$logLevel('['.$apiName.'] '.$message);
     }
 
     /**

--- a/src/API/AbstractAPIClient.php
+++ b/src/API/AbstractAPIClient.php
@@ -65,11 +65,7 @@ abstract class AbstractAPIClient implements APIInterface
 
             return $response;
         } catch (RequestException $e) {
-            $jsonResponse = json_decode($e->getResponse()->getBody(), true);
-            $errorMessage = $e->getMessage();
-            if (count($jsonResponse['errors']) > 0) {
-                $errorMessage = $jsonResponse['errors'][0]['message'];
-            }
+            $errorMessage = getErrorMessage($e);
 
             $this->logAPICall($this->getAPIClientName(), array(
                 'type' => 'request',

--- a/src/API/AbstractAPIClient.php
+++ b/src/API/AbstractAPIClient.php
@@ -120,4 +120,11 @@ abstract class AbstractAPIClient implements APIInterface
      * @return mixed
      */
     abstract public function getAPIClientName();
+
+    /**
+     * @param $message
+     *
+     * @return array
+     */
+    abstract public function createAPIError($message);
 }

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -49,6 +49,22 @@ class Client extends AbstractAPIClient
     }
 
     /**
+     * @param RequestException object
+     *
+     * @return string
+     */
+    public function getErrorMessage($error)
+    {
+        $jsonResponse = json_decode($error->getResponse()->getBody(), true);
+        $errorMessage = $error->getMessage();
+        if (count($jsonResponse['errors']) > 0) {
+            $errorMessage = $jsonResponse['errors'][0]['message'];
+        }
+
+        return $errorMessage;
+    }
+
+    /**
      * @param $response
      *
      * @return bool

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -2,6 +2,8 @@
 
 namespace CF\API;
 
+use GuzzleHttp\Exception\RequestException;
+
 class Client extends AbstractAPIClient
 {
     const CLIENT_API_NAME = 'CLIENT API';
@@ -49,14 +51,15 @@ class Client extends AbstractAPIClient
     }
 
     /**
-     * @param RequestException object
+     * @param RequestException error
      *
      * @return string
      */
-    public function getErrorMessage($error)
+    public function getErrorMessage(RequestException $error)
     {
         $jsonResponse = json_decode($error->getResponse()->getBody(), true);
         $errorMessage = $error->getMessage();
+
         if (count($jsonResponse['errors']) > 0) {
             $errorMessage = $jsonResponse['errors'][0]['message'];
         }

--- a/src/Test/API/ClientTest.php
+++ b/src/Test/API/ClientTest.php
@@ -80,4 +80,37 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->mockClientAPI->responseOk($v4APIResponse));
     }
+
+    public function testGetErrorMessageSuccess()
+    {
+        $errorMessage = 'I am an error message';
+
+        $error = $this->getMockBuilder('GuzzleHttp\Exception\RequestException')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getResponse', 'getBody', 'getMessage'))
+            ->getMock();
+
+        $errorJSON = json_encode(
+            array(
+                'success' => false,
+                'errors' => array(
+                    array(
+                        'message' => $errorMessage,
+                    ),
+                ),
+            )
+        );
+
+        $error->expects($this->any())
+            ->method('getMessage')
+            ->will($this->returnValue('Not this message'));
+        $error->expects($this->any())
+            ->method('getResponse')
+            ->will($this->returnSelf());
+        $error->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue($errorJSON));
+
+        $this->assertEquals($errorMessage, $this->mockClientAPI->getErrorMessage($error));
+    }
 }


### PR DESCRIPTION
…or message

I edited `AbstractAPIClient.php` instead of `Client.php`. The reasoning is `createAPIError` should only get a string argument and print it. So the function in `Client.php` was correct but the argument sent was not correct.

For feature `callAPI` usages which are not to `api.cloudflare`but to another API there is this check 

`if (count($jsonResponse['errors']) > 0)` 

Since php gives warning if array key doesn't exist this check shouldn't crash even if `$jsonResponse['errors']` does not exist. The only bad scenario is if the API response has `count($jsonResponse['errors']) > 0` but doesn't have `'message'` the response would be null I believe. 
