### PR TITLE
PI-996 move Guzzle to require-dev in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,12 @@
     "format": "vendor/bin/phpcs -n --standard=PSR2 --extensions=php,live.php src/"
   },
   "require": {
-    "psr/log": "^1.0",
-    "guzzle/guzzle": "~3.9"
+    "psr/log": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",
-    "squizlabs/php_codesniffer": "2.*"
+    "squizlabs/php_codesniffer": "2.*",
+    "guzzle/guzzle": "~3.9"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I did not change the guzzle version to 5.x. That is a big change regardless. Currently Guzzle 3.x works as expected. If we have any issues with it we can upgrade it.