### PR TITLE
Removing Guzzle type hints on getErrorMessage() so tests mock correct…

### DIFF
--- a/src/API/AbstractAPIClient.php
+++ b/src/API/AbstractAPIClient.php
@@ -122,7 +122,7 @@ abstract class AbstractAPIClient implements APIInterface
     }
 
     /**
-     * @param BadResponseException $object
+     * @param $error
      *
      * @return string
      */

--- a/src/API/AbstractAPIClient.php
+++ b/src/API/AbstractAPIClient.php
@@ -126,7 +126,7 @@ abstract class AbstractAPIClient implements APIInterface
      *
      * @return string
      */
-    public function getErrorMessage(BadResponseException $error)
+    public function getErrorMessage($error)
     {
         return $error->getMessage();
     }

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -60,7 +60,7 @@ class Client extends AbstractAPIClient
      *
      * @return string
      */
-    public function getErrorMessage(BadResponseException $error)
+    public function getErrorMessage($error)
     {
         $jsonResponse = json_decode($error->getResponse()->getBody(), true);
         $errorMessage = $error->getMessage();

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -56,7 +56,7 @@ class Client extends AbstractAPIClient
     }
 
     /**
-     * @param BadResponseException error
+     * @param error
      *
      * @return string
      */


### PR DESCRIPTION
…ly on Wordpress.

Is one step towards fixing https://github.com/cloudflare/Cloudflare-WordPress/pull/174