### PR TITLE
Add support for API Tokens

### DIFF
--- a/src/API/AbstractPluginActions.php
+++ b/src/API/AbstractPluginActions.php
@@ -90,7 +90,7 @@ abstract class AbstractPluginActions
         }
 
         //Make a test request to see if the API Key, email are valid
-        $testRequest = new Request('GET', 'accounts/', array(), array());
+        $testRequest = new Request('GET', 'zones/', array(), array());
         $testResponse = $this->clientAPI->callAPI($testRequest);
         if (!$this->clientAPI->responseOk($testResponse)) {
             //remove bad credentials

--- a/src/API/AbstractPluginActions.php
+++ b/src/API/AbstractPluginActions.php
@@ -90,7 +90,7 @@ abstract class AbstractPluginActions
         }
 
         //Make a test request to see if the API Key, email are valid
-        $testRequest = new Request('GET', 'user/', array(), array());
+        $testRequest = new Request('GET', 'accounts/', array(), array());
         $testResponse = $this->clientAPI->callAPI($testRequest);
         if (!$this->clientAPI->responseOk($testResponse)) {
             //remove bad credentials

--- a/src/API/Client.php
+++ b/src/API/Client.php
@@ -12,6 +12,7 @@ class Client extends AbstractAPIClient
     const X_AUTH_KEY = 'X-Auth-Key';
     const X_AUTH_EMAIL = 'X-Auth-Email';
     const AUTHORIZATION = 'Authorization';
+    const AUTH_KEY_LEN = 37;
 
     /**
      * @param Request $request
@@ -28,7 +29,7 @@ class Client extends AbstractAPIClient
         // Determine authentication method from key format. Global API keys are
         // always returned in hexadecimal format, while API Tokens are encoded
         // using a wider range of characters.
-        if (preg_match('/^[0-9a-f]+$/', $key)) {
+        if (strlen($key) === AUTH_KEY_LEN && preg_match('/^[0-9a-f]+$/', $key)) {
             $headers[self::X_AUTH_EMAIL] = $this->data_store->getCloudFlareEmail();
             $headers[self::X_AUTH_KEY] = $key;
         } else {


### PR DESCRIPTION
This commit adds provisional support for accepting and disambiguating between API keys and API
Tokens, provided in the same field of the underlying data store. Depending on the format of the
value given, we set appropriate authentication headers, to be accepted in API calls to Cloudflare.

The target of the test request has also been updated from `/user` to `/accounts`, which is available
to both API keys and API Tokens.