### PR TITLE
Issue #255 Scope test api request to current zone

### DIFF
--- a/src/API/AbstractPluginActions.php
+++ b/src/API/AbstractPluginActions.php
@@ -89,9 +89,16 @@ abstract class AbstractPluginActions
             return $this->api->createAPIError('Unable to save user credentials');
         }
 
+        $params = array();
+        // Only Wordpress gives us access to the zone name, so check for it here
+        if ($this->integrationAPI instanceof \CF\WordPress\WordPressAPI) {
+            $params =  array('name' => $this->integrationAPI->getOriginalDomain());
+        }
+
         //Make a test request to see if the API Key, email are valid
-        $testRequest = new Request('GET', 'zones/', array(), array());
+        $testRequest = new Request('GET', 'zones/', $params, array());
         $testResponse = $this->clientAPI->callAPI($testRequest);
+
         if (!$this->clientAPI->responseOk($testResponse)) {
             //remove bad credentials
             $this->dataStore->createUserDataStore(null, null, null, null);

--- a/src/Test/API/AbstractPluginActionsTest.php
+++ b/src/Test/API/AbstractPluginActionsTest.php
@@ -34,11 +34,14 @@ class AbstractPluginActionsTest extends \PHPUnit_Framework_TestCase
         $this->mockAbstractPluginActions = $this->getMockBuilder('CF\API\AbstractPluginActions')
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $this->mockAbstractPluginActions->setRequest($this->mockRequest);
+        $this->mockDefaultIntegration = $this->getMockBuilder('\CF\Integration\DefaultIntegration')
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
         $this->mockAbstractPluginActions->setAPI($this->mockAPIClient);
         $this->mockAbstractPluginActions->setClientAPI($this->mockClientAPI);
         $this->mockAbstractPluginActions->setDataStore($this->mockDataStore);
         $this->mockAbstractPluginActions->setLogger($this->mockLogger);
+        $this->mockAbstractPluginActions->setRequest($this->mockRequest);
     }
 
     public function testPostAccountSaveAPICredentialsReturnsErrorIfMissingApiKey()
@@ -47,6 +50,7 @@ class AbstractPluginActionsTest extends \PHPUnit_Framework_TestCase
             'email' => 'email',
         ));
         $this->mockAPIClient->method('createAPIError')->willReturn(array('success' => false));
+        $this->mockDefaultIntegration->method('getOriginalDomain')->willReturn('name.com');
 
         $response = $this->mockAbstractPluginActions->login();
 
@@ -59,6 +63,7 @@ class AbstractPluginActionsTest extends \PHPUnit_Framework_TestCase
             'apiKey' => 'apiKey',
         ));
         $this->mockAPIClient->method('createAPIError')->willReturn(array('success' => false));
+        $this->mockDefaultIntegration->method('getOriginalDomain')->willReturn('name.com');
 
         $response = $this->mockAbstractPluginActions->login();
 
@@ -130,6 +135,8 @@ class AbstractPluginActionsTest extends \PHPUnit_Framework_TestCase
         ));
         $this->mockDataStore->method('createUserDataStore')->willReturn(true);
         $this->mockClientAPI->method('responseOk')->willReturn(false);
+        $this->mockDefaultIntegration->method('getOriginalDomain')->willReturn('name.com');
+
         $this->mockAPIClient->expects($this->once())->method('createAPIError');
         $this->mockAbstractPluginActions->login();
     }


### PR DESCRIPTION
This helps out folks that scope API tokens to a single zone, that is after all the point of API tokens.